### PR TITLE
Add example of rd.xml file

### DIFF
--- a/Samples/Reflection/Function.cs
+++ b/Samples/Reflection/Function.cs
@@ -42,6 +42,7 @@ public class SampleItemWithProperties
 // Comment out this partial class and attributes to see the runtime error for yourself (the error can be seen at the bottom of this file)
 [JsonSerializable(typeof(SampleItemWithProperties))]
 [JsonSerializable(typeof(DateTimeOffset?))]
+[JsonSerializable(typeof(string))]
 public partial class MyCustomJsonSerializerContext : JsonSerializerContext
 {
     // By using this partial class derived from JsonSerializerContext, we can generate reflection free JSON Serializer code at compile time

--- a/Samples/Reflection/Function.cs
+++ b/Samples/Reflection/Function.cs
@@ -39,7 +39,11 @@ public class SampleItemWithProperties
     public DateTimeOffset? CreatedDate {get; set;}
 }
 
-// Comment out this partial class and attributes to see the runtime error for yourself (the error can be seen at the bottom of this file)
+// To see the runtime error for yourself:
+// Comment out this partial class and attributes
+// Then replace `new SourceGeneratorLambdaJsonSerializer<MyCustomJsonSerializerContext>()` above with:
+// new DefaultLambdaJsonSerializer()
+// (the error you can expect to see at runtime is at the bottom of this file, MissingMetadataException)
 [JsonSerializable(typeof(SampleItemWithProperties))]
 [JsonSerializable(typeof(DateTimeOffset?))]
 [JsonSerializable(typeof(string))]

--- a/Samples/Reflection/README.md
+++ b/Samples/Reflection/README.md
@@ -1,13 +1,19 @@
 # Reflection with NativeAOT
 
-This sample was mainly created to help explain how to fix [reflection issues with NativeAOT](https://github.com/dotnet/runtimelab/blob/feature/NativeAOT/docs/using-nativeaot/reflection-in-aot-mode.md).
-
-After reading the above link you should hopefully understand why reflection can cause problem with NativeAOT.
+This sample was mainly created to help explain how to fix [reflection issues with NativeAOT](https://github.com/dotnet/runtimelab/blob/feature/NativeAOT/docs/using-nativeaot/reflection-in-aot-mode.md). After reading that link you should hopefully understand why reflection can cause problem with NativeAOT.
 
 One thing that often requires a lot of reflection is JSON serialization. Luckily we already have a way to generate reflection-free JSON serializers with Lambda using [System.Text.Json source generators](https://devblogs.microsoft.com/dotnet/try-the-new-system-text-json-source-generator/). See the section titled 'Using source generator for JSON serialization' of [this AWS blog](https://aws.amazon.com/blogs/compute/introducing-the-net-6-runtime-for-aws-lambda/#Using%20source%20generator%20for%20JSON%20serialization).
 
-To deploy this code, just run `dotnet lambda deploy-function --function-name reflectionTestNativeAOT`
+This code should work as-is. To deploy and test this code
+* Make sure you have [configured your AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html)
+* Make sure you are on AL2, either through docker or WSL (see main [README](../../README.md) for more details)
+* Navigate your terminal to the project root folder
+* Run `dotnet lambda deploy-function --function-name reflectionTestNativeAOT` to deploy
+* Run `aws lambda list-functions` to list your functions, and take the ARN of your new function and put it into the next command
+* Run `dotnet lambda invoke-function arn:aws:lambda:us-east-1:1234567890:function:reflectionTestNativeAOT --payload "Hello World"` (Replacing the ARN with your real ARN) to test the function. You can also log into the AWS web console and test there. 
 
-And then test the deployed function with this command (updated for your function ARN, you can use `aws lambda list-functions` to see all your function ARNs) `dotnet lambda invoke-function arn:aws:lambda:us-east-1:1234567890:function:reflectionTestNativeAOT --payload "Hello World"`
+Looking at the code, you can see that we implement a custom JsonSerializerContext which allows us to deserialize our object without hitting a `MissingMetadataException` at runtime.
 
-You can see that we implement a custom JsonSerializerContext which allows us to deserialize our object without hitting a `MissingMetadataException` at runtime.
+If you want to see the MissingMetadataException for yourself, just comment out the partial class called `MyCustomJsonSerializerContext` along with its attributes. Then replace `new SourceGeneratorLambdaJsonSerializer<MyCustomJsonSerializerContext>()` with `new DefaultLambdaJsonSerializer()`. This will use reflection to do the deserialization. Then System.Text.Json will attempt to dynamically create a `NullableConverter<DateTimeOffset>` to do the deserialization, but since `NullableConverter<DateTimeOffset>` is not used anywhere in the code and has already been trimmed out, it won't know how to do it.
+
+You can also fix this error without a custom JSON serializer. You might want to do this for other errors in the case where it's not related to serialization or you don't have access to modify the underlying library. To do this, you can use an [rd.xml](https://github.com/dotnet/runtimelab/blob/feature/NativeAOT/docs/using-nativeaot/rd-xml-format.md) file. We've already included the `rd.xml` file in the project folder which you need. All you have to do it uncomment out the `ItemGroup` in the .csproj file that contains `<RdXmlFile Include="rd.xml" />` to actually use it. With this file, we're telling the compiler ahead of time, that we need to know how to construct a `NullableConverter` of type `DateTimeOffset`. Now, with the rd.xml file, you can use the `DefaultLambdaJsonSerializer` and still not hit a `MissingMetadataException` at runtime. This should give you a path to fix all NativeAOT specific runtime errors.

--- a/Samples/Reflection/Reflection.csproj
+++ b/Samples/Reflection/Reflection.csproj
@@ -1,26 +1,29 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <AWSProjectType>Lambda</AWSProjectType>
-    <AssemblyName>bootstrap</AssemblyName>
-    <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-  </PropertyGroup>
-  <!-- 
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net6.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<AWSProjectType>Lambda</AWSProjectType>
+		<AssemblyName>bootstrap</AssemblyName>
+		<!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
+		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+	</PropertyGroup>
+	<!-- 
   When publishing Lambda functions for ARM64 to the provided.al2 runtime a newer version of libicu needs to be included
   in the deployment bundle because .NET requires a newer version of libicu then is preinstalled with Amazon Linux 2.
   -->
-  <ItemGroup Condition="'$(RuntimeIdentifier)' == 'linux-arm64'">
-    <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="68.2.0.9" />
-    <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="68.2.0.9" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.8.0" />
-    <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
-    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="7.0.0-*" />
-  </ItemGroup>
+	<ItemGroup Condition="'$(RuntimeIdentifier)' == 'linux-arm64'">
+		<RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="68.2.0.9" />
+		<PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="68.2.0.9" />
+	</ItemGroup>
+	<!--<ItemGroup>
+		<RdXmlFile Include="rd.xml" />
+	</ItemGroup>-->
+	<ItemGroup>
+		<PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.8.0" />
+		<PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
+		<PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
+		<PackageReference Include="Microsoft.DotNet.ILCompiler" Version="7.0.0-*" />
+	</ItemGroup>
 </Project>

--- a/Samples/Reflection/rd.xml
+++ b/Samples/Reflection/rd.xml
@@ -1,0 +1,7 @@
+﻿<Directives>
+	<Application>
+		<Assembly Name="System.Text.Json">
+			<Type Name="System.Text.Json.Serialization.Converters.NullableConverter`1[[System.DateTimeOffset,mscorlib]]" Dynamic="Required All" />
+		</Assembly>
+	</Application>
+</Directives>


### PR DESCRIPTION
This shows how you can use the rd.xml file to fix runtime errors.

I also need to add an attribute for string. Without this, the custom serializer throws and error that it can't deserialize the string input.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
